### PR TITLE
fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,14 @@ PYTHONPATH := '.'
 IMAGE := ryoma
 VERSION := latest
 
+.PHONY: poetry-download
+poetry-download:
+	curl -sSL https://install.python-poetry.org | python3 -
+
+.PHONY: poetry-remove
+poetry-remove:
+	curl -sSL https://install.python-poetry.org | python3 - --uninstall
+
 .PHONY: uv-download
 uv-download:
 	curl -LsSf https://astral.sh/uv/install.sh | sh


### PR DESCRIPTION
## Description
Running make poetry-download in the root directory of trt gives an error, the makefile does not have this field.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://github.com/project-ryoma/ryoma/issues/614
<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/ryoma/ryoma/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/ryoma/ryoma/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
