### PR TITLE
docs: edit README link from first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install ryoma_ai[snowflake]
 
 ## Basic Example
 Below is an example of using SqlAgent to connect to a postgres database and ask a question.
-You can read more details in the [documentation](https://ryoma-1.gitbook.io/ryoma/).
+You can read more details in the [documentation](https://project-ryoma.github.io/ryoma/).
 
 ```python
 from ryoma_ai.agent.sql import SqlAgent


### PR DESCRIPTION
## Description

I tried open the link from 1st example but failed or was not found. I fixed it updating the currently link from the documentation

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/ryoma/ryoma/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/ryoma/ryoma/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
